### PR TITLE
#11153: [Footer][Contact info]Link to email Hr is NOT active

### DIFF
--- a/resources/views/clients/layout/footer.blade.php
+++ b/resources/views/clients/layout/footer.blade.php
@@ -27,7 +27,7 @@
                                     <li>
                                         <i class="fa fa-envelope"></i>
                                         @lang('lang.email'):
-                                        <a href="#">{{ config('settings.company.hr_email_company') }}</a>
+                                        {{ config('settings.company.hr_email_company') }}
                                     </li>
                                 </ul>
                             </div>


### PR DESCRIPTION
Description

Summary : NOT redirect to email form, and allow SEND mail to hr 's mail

Step to reproduce:
1. Open Fsurvey hompage
2. Click on hr link " hr_team@sun-asterisk.com" in [Contact info] tab
3. Verify action
Actual result : Move on top of page, and not redirect to send email form.

Expected result : Redirect to email form, and allow send mail to hr 's mail
Attachments file: Hr_Mail.gif
Env: Staging
OS: Windown 10
Browser: Google Chrome 73.0.3683.103

https://edu-redmine.sun-asterisk.vn/issues/11153

Đã thảo luận lại với QA và Trainner. Vì phần này nếu làm như trên sẽ giống với phản hồi và user chỉ có thể gửi mail với hr thông qua hệ thống => Chỉ để chữ như Fpoll