### PR TITLE
Bug #11355 [Manager survey][Survey status]DOES NOT auto CHANGE survey 's status from "Open" to "Close" when TIME UP

### DIFF
--- a/app/Http/Controllers/Survey/SurveyManagementController.php
+++ b/app/Http/Controllers/Survey/SurveyManagementController.php
@@ -55,12 +55,21 @@ class SurveyManagementController extends Controller
 
     public function showSurveys()
     {
+        DB::beginTransaction();
         try {
             $user = Auth::user();
             $surveys = $this->surveyRepository->getAuthSurveys(config('settings.survey.members.owner'));
+            foreach ($surveys as $survey) {
+                $timeRemaining = $survey->remaining_time;
+                if (!$timeRemaining)
+                    $this->surveyRepository->updateSurveyByObject($survey, ['status' => config('settings.survey.status.close')]);
+            }
+            DB::commit();
 
             return view('clients.profile.list-survey', compact('user', 'surveys'));
         } catch (Exception $e) {
+            DB::rollback();
+            
             return view('clients.layout.404');
         }
     }

--- a/app/Repositories/Survey/SurveyRepository.php
+++ b/app/Repositories/Survey/SurveyRepository.php
@@ -980,7 +980,6 @@ class SurveyRepository extends BaseRepository implements SurveyInterface
             });
         }
 
-
         if (isset($data['status']) && $data['status']) {
             $survey = $survey->where('status', $data['status']);
         }


### PR DESCRIPTION
![Peek 2019-05-04 10-52](https://user-images.githubusercontent.com/48110607/57173501-fbac5d00-6e5a-11e9-935b-38373b07e5bd.gif)

https://edu-redmine.sun-asterisk.vn/issues/11355

Summary : DOES NOT auto CHANGE survey 's status from "Open" to "Close" when TIME UP
Pre-condition: Has a survey when time up
Step to reproduce:
1. Open manager list of survey
2. Focus to status of survey which time up to doing survey
Actual result : has status "OPEN" 
Expected result :Auto change to "CLOSE" when time up
Attachments change_close.png
Env: Staging
OS: Windown 10
Browser: Google Chrome 73.0.3683.103 

Trường hợp này đã được xử lý với task schedule => Close để thảo luận lại với QA