### PR TITLE
[Create survey]Should set DEFAULT data in "Time to start survey" = current time

### DIFF
--- a/resources/assets/templates/survey/js/builder-custom.js
+++ b/resources/assets/templates/survey/js/builder-custom.js
@@ -1269,8 +1269,8 @@ jQuery(document).ready(function () {
 
         // if start-time select <= time now
         if (diffdateNow >= 0) {
-            // start-time must after time now 30 min
-            dateSelect = new Date(dateNow.getTime() + 30 * 1000 * 60);
+            // start-time must be equals time now
+            dateSelect = new Date(dateNow.getTime() * 1000 * 60);
             $(this).data('datetimepicker').date(dateSelect);
 
             return;


### PR DESCRIPTION
Summary : Should set DEFAULT data in "Time to start survey" = current time, not "Current time + 30minute" 
Step to reproduce:
1. Open create survey 
2. Focus to time display on textbox
Actual result : Display "Curent time + 30 minute" when click on textbox 
Expected result : Display "Current time" 
Attachments: set_Default_time.png

![Peek 2019-05-06 17-05](https://user-images.githubusercontent.com/48110607/57219200-8474f580-7021-11e9-97e3-31cc2c54deda.gif)

https://edu-redmine.sun-asterisk.vn/issues/11317