### PR TITLE
[UI][Setting page]header OVERLAP survey infomation

### DIFF
--- a/resources/views/clients/survey/detail/detail_survey.blade.php
+++ b/resources/views/clients/survey/detail/detail_survey.blade.php
@@ -9,11 +9,6 @@
             {{ Html::image(asset(config('settings.background_survey')), '', ['class' => 'image-header']) }}
         @endif
     </div>
-    <div class="info-survey-block">
-        <span>{{ trans('lang.creator') . $data['survey']->owner_name }}</span><br/>
-        <span>{{ trans('lang.date_create') . $data['survey']->created_at }}</span><br/>
-        <span>{{ !empty($data['survey']->time_finish) ? trans('lang.time_finish') . $data['survey']->time_finish : '' }}</span>
-    </div>
     @can('config', $data['survey'])
         <a href="{{ route('survey.management', $data['survey']->token_manage) }}" class="btn btn-primary member-config-btn">
             <i class="fa fa-cog"></i>


### PR DESCRIPTION
Summary : Header of page overlap survey information tab
Pre-condition: Has a survey
Step to reproduce:
1. Open setting page of survey 
2. Focus to the right of header 
Actual result : Overlap text
Expected result : Infomation tab is hide