### PR TITLE
Bug #11738: [Edit survey] NOT display error msg when "Time to finish the survey" < curent time

### DIFF
--- a/resources/assets/templates/survey/js/builder-custom.js
+++ b/resources/assets/templates/survey/js/builder-custom.js
@@ -1084,6 +1084,20 @@ jQuery(document).ready(function () {
         return true;
     }, Lang.get('validation.msg.after_start_time'));
 
+    // add validation end time must after now for edit servey
+    $.validator.addMethod('end_time_after_now', function (value, element) {
+        var today = new Date();
+        var endDate = value;
+
+        today = moment().format('DD/MM/YYYY h:mm A');
+        
+        if (today > value) {
+            return false;
+        }
+
+        return true;
+    }, Lang.get('validation.msg.end_time_after_now'));
+
     // section unique rule
     $.validator.addMethod('sectionunique', function (value, element) {
         var parentForm = $(element).closest('form');
@@ -1198,6 +1212,9 @@ jQuery(document).ready(function () {
                 title: {
                     required: true,
                     maxlength: 255
+                },
+                end_time: {
+                    end_time_after_now: true,
                 },
             }
         });

--- a/resources/lang/en/validation.php
+++ b/resources/lang/en/validation.php
@@ -142,6 +142,7 @@ return [
         'tailmail' => 'You must enter at least one type of email',
         'start_time_after_now' => 'The start of survey must be after time now.',
         'after_start_time' => 'The end of the survey must be at least 30 minutes after the start time.',
+        'end_time_after_now' => 'The end of the survey must be after time now.',
         'more_than_30_minutes' => 'The closing time must be at least 30 minutes longer than the current time.',
         'duplicate_section_title' => 'The title of the section is identical',
         'duplicate_question_title' => 'There is a question that coincides with this question',

--- a/resources/lang/jp/validation.php
+++ b/resources/lang/jp/validation.php
@@ -142,6 +142,7 @@ return [
         'tailmail' => 'You must enter at least one type of email',
         'start_time_after_now' => 'The start of survey must be after time now.',
         'after_start_time' => 'The end of the survey must be at least 30 minutes after the start time.',
+        'end_time_after_now' => 'The end of the survey must be after time now.',
         'more_than_30_minutes' => 'The closing time must be at least 30 minutes longer than the current time.',
         'duplicate_section_title' => 'The title of the section is identical',
         'duplicate_question_title' => 'There is a question that coincides with this question',

--- a/resources/lang/vn/validation.php
+++ b/resources/lang/vn/validation.php
@@ -142,6 +142,7 @@ return [
         'tailmail' => 'Bạn phải nhập tối thiểu một loại email',
         'start_time_after_now' => 'Thời gian bắt đầu khảo sát phải sau thời gian hiện tại.',
         'after_start_time' => 'Thời gian kết thúc khảo sát phải sau thời gian bắt đầu ít nhất 30 phút.',
+        'end_time_after_now' => 'Thời gian kết thúc khảo sát phải sau thời gian hiện tại.',
         'more_than_30_minutes' => 'Thời gian kết thúc cuộc khảo sát phải sau thời gian hiện tại ít nhất 30 phút.',
         'duplicate_section_title' => 'Tiêu đề phần đã bị trùng',
         'duplicate_question_title' => 'Đã có một câu hỏi trùng với câu hỏi này',


### PR DESCRIPTION
Summary : System not display error msg and still allow edit success when "Time to finish the survey" < curent time
Pre-condition: Has a survey when time up
Step to reproduce:
1. Open edit survey Screen
2. Edit survey and click on button "Send" 
3. Focus "Time to finish the survey" 
Actual result : not display error msg and still allow edit success
Expected result :Display msg "Time to finish the survey have to after current time" 

https://edu-redmine.sun-asterisk.vn/issues/11738
![Peek 2019-05-07 14-45](https://user-images.githubusercontent.com/48110607/57282224-d1ff6a00-70d6-11e9-96d8-df2704dbbd33.gif)
