### PR TITLE
Reopen bug 11738: [Edit survey] NOT display error msg when "Time to finish the survey" < curent time

### DIFF
--- a/resources/assets/templates/survey/js/builder-custom.js
+++ b/resources/assets/templates/survey/js/builder-custom.js
@@ -1087,11 +1087,12 @@ jQuery(document).ready(function () {
     // add validation end time must after now for edit servey
     $.validator.addMethod('end_time_after_now', function (value, element) {
         var today = new Date();
-        var endDate = value;
 
-        today = moment().format('DD/MM/YYYY h:mm A');
-        
-        if (today > value) {
+        var endDate = value;
+        endDate = endDate.split('/')[1] + '-' + endDate.split('/')[0] + endDate.substring(5);
+        endDate = new Date(Date.parse(endDate));        
+
+        if (today.getTime() > endDate.getTime()) {
             return false;
         }
 


### PR DESCRIPTION
Summary : System not display error msg and still allow edit success when "Time to finish the survey" < curent time
Pre-condition: Has a survey when time up
Step to reproduce:
1. Open edit survey Screen
2. Edit survey and click on button "Send" 
3. Focus "Time to finish the survey" 
Actual result : not display error msg and still allow edit success
Expected result :Display msg "Time to finish the survey have to after current time" 

https://edu-redmine.sun-asterisk.vn/issues/11738
![Peek 2019-05-07 14-45](https://user-images.githubusercontent.com/48110607/57282224-d1ff6a00-70d6-11e9-96d8-df2704dbbd33.gif)
