### PR TITLE
[List of survey][Inviting column][Status pop-up]NOT RESET Search text…

### DIFF
--- a/resources/assets/templates/survey/js/manage-invite.js
+++ b/resources/assets/templates/survey/js/manage-invite.js
@@ -1,12 +1,12 @@
-$(document).ready(function() {
+$(document).ready(function () {
     $('[data-toggle="tooltip"]').tooltip();
     var tokenManage = '';
 
-    $(document).on('click', '.process-bar-survey', function(event) {
+    $(document).on('click', '.process-bar-survey', function (event) {
         var numberIncognitoAnswer = $(this).attr('data-incognito-answer');
 
         if (parseInt(numberIncognitoAnswer)) {
-            $('.number-incognito-answer').text(Lang.get('lang.count_incognito_answer', {count: numberIncognitoAnswer}));
+            $('.number-incognito-answer').text(Lang.get('lang.count_incognito_answer', { count: numberIncognitoAnswer }));
         }
 
         event.preventDefault();
@@ -14,22 +14,22 @@ $(document).ready(function() {
         showStatusAnswer(tokenManage);
     });
 
-    $(document).on('click', '.emails-not-answer', function(event) {
+    $(document).on('click', '.emails-not-answer', function (event) {
         event.preventDefault();
         showStatusAnswer(tokenManage, 2);
     });
 
-    $(document).on('click', '.emails-answered', function(event) {
+    $(document).on('click', '.emails-answered', function (event) {
         event.preventDefault();
         showStatusAnswer(tokenManage, 1);
     });
 
-    $(document).on('click', '.all-email', function(event) {
+    $(document).on('click', '.all-email', function (event) {
         event.preventDefault();
         showStatusAnswer(tokenManage);
     });
 
-    $(document).on('keyup', '.search-mail-invite', function(event) {
+    $(document).on('keyup', '.search-mail-invite', function (event) {
         event.preventDefault();
         var text = $(this).val();
         showStatusAnswer(tokenManage, '', text);
@@ -43,50 +43,54 @@ $(document).ready(function() {
                 token_manage: tokenManage,
             },
         })
-        .done(function(data) {
-            if (data.success) {
-                var array = data.data;
+            .done(function (data) {
+                if (data.success) {
+                    var array = data.data;
 
-                if (text) {
-                    array = find(text, array);
-                }
+                    if (text) {
+                        array = find(text, array);
+                    }
 
-                $('.body-table-invite-status').empty();
+                    $('.body-table-invite-status').empty();
 
-                if (array.length) {
-                    $('.notice-data-empty').hide();
-                    $('.table-invite').show();
+                    if (array.length) {
+                        $('.notice-data-empty').hide();
+                        $('.table-invite').show();
 
-                    var index = 0;
-                    array.forEach(function(item) {
-                        if (status == 1 && !item['count']) {
-                            return;
-                        }
+                        var index = 0;
+                        array.forEach(function (item) {
+                            if (status == 1 && !item['count']) {
+                                return;
+                            }
 
-                        if (status == 2 && item['count']) {
-                            return;
-                        }
+                            if (status == 2 && item['count']) {
+                                return;
+                            }
 
-                        var element = item['count']
-                            ? `<span class="fa fa-circle green"></span>`
-                            : `<span class="fa fa-circle blue">`;
+                            var element = item['count']
+                                ? `<span class="fa fa-circle green"></span>`
+                                : `<span class="fa fa-circle blue">`;
 
-                        $('.body-table-invite-status').append(`
+                            $('.body-table-invite-status').append(`
                             <tr>
-                                <td width="15%">${++ index}</td>
+                                <td width="15%">${++index}</td>
                                 <td>${item['email']}</td>
                                 <td width="20%"><span class="inviter-description">${element}</span></td>
                                 <td width="15%">${item['count']}</td>
                             </tr>
                         `);
-                    });
-                } else {
-                    $('.notice-data-empty').show();
-                    $('.table-invite').hide();
+                        });
+                    } else {
+                        $('.notice-data-empty').show();
+                        $('.table-invite').hide();
+                    }
                 }
-            }
-        });
+            });
     }
+
+    $('.progress.process-bar-survey').on('click', function () {
+        $('.form-control.search-mail-invite').val('');
+    });
 
     function find(text, array) {
         var result = [];


### PR DESCRIPTION
Summary : Not reset "Search" textbox when close "Status" pop-up
Step to reproduce : 
1. Open list off survey. 
2. Click on button "Inviting" in each record
3. On pop-up "Status", enter "n9" into "search" textbox 
4. Close pop-up
5. Open "Status" pop-up again
6. Focus "search" textbox 
Actual result : Display previous value
Expected result : Set default data of search textbox is Null. Reset when close pop-uo "Status" 