### PR TITLE
[Profile screen][Account Setting][Change password] Should display error msg NEARBY textbox "New password"

### DIFF
--- a/resources/assets/templates/survey/css/theme-styles.css
+++ b/resources/assets/templates/survey/css/theme-styles.css
@@ -1055,3 +1055,9 @@ input.submit-image-profile:hover {
         width: 100%;
     }
 }
+
+.error {
+    color: #FF0000;
+    font-weight: 100;
+    font-size: 15px;
+}

--- a/resources/assets/templates/survey/js/survey.js
+++ b/resources/assets/templates/survey/js/survey.js
@@ -88,6 +88,34 @@ $(document).ready(function () {
     $(document).on('click', '.survey-close', function () {
         alertWarning({message: Lang.get('lang.survey_close')});
     });
+
+    $.validator.addMethod("validatePassword", function (value, element) {
+        return this.optional(element) || /^\S*(?=\S*[a-zA-Z])(?=\S*[\W])(?=\S*[\d])\S*$/.test(value);
+    }, Lang.get('validation.password_without_spaces_and_require_letter_number_special_character'));
+
+    $("#change-password").validate({
+        debug: false,
+        rules: {
+            "newpassword": {
+                validatePassword: true,
+            },
+            "retypepassword": {
+                equalTo: '#newpassword',
+            }
+        },
+        messages: {
+            "oldpassword": {
+                required: Lang.get('validation.msg.required'),
+            },
+            "newpassword": {
+                required: Lang.get('validation.msg.required'),
+            },
+            "retypepassword": {
+                equalTo: Lang.get('validation.msg.re_password'),
+                required: Lang.get('validation.msg.required'),
+            }
+        }
+    });
 });
 
 function listSurvey(url, flag = 'form-search') {

--- a/resources/lang/en/validation.php
+++ b/resources/lang/en/validation.php
@@ -124,6 +124,7 @@ return [
         'required' => 'This field is required.',
         'remote' => 'Please fix this field.',
         'email' => 'Please enter a valid email address.',
+        're_password' => 'Your new password and confirmation password do not match ',
         'url' => 'Please enter a valid URL.',
         'date' => 'Please enter a valid date.',
         'dateISO' => 'Please enter a valid date (ISO).',

--- a/resources/lang/jp/validation.php
+++ b/resources/lang/jp/validation.php
@@ -124,6 +124,7 @@ return [
         'required' => 'This field is required.',
         'remote' => 'Please fix this field.',
         'email' => 'Please enter a valid email address.',
+        're_password' => 'Your new password and confirmation password do not match ',
         'url' => 'Please enter a valid URL.',
         'date' => 'Please enter a valid date.',
         'dateISO' => 'Please enter a valid date (ISO).',

--- a/resources/lang/vn/validation.php
+++ b/resources/lang/vn/validation.php
@@ -124,6 +124,7 @@ return [
         'required' => 'Thông tin bắt buộc',
         'remote' => 'Hãy sửa trừờng này.',
         'email' => 'Email không hợp lệ.',
+        're_password' => 'Không khớp với mật khẩu mới',
         'url' => 'Url không hợp lệ.',
         'date' => 'Ngày không hợp lệ.',
         'dateISO' => 'Vui lòng nhập ngày hợp lệ (ISO).',

--- a/resources/views/clients/profile/changepassword.blade.php
+++ b/resources/views/clients/profile/changepassword.blade.php
@@ -24,7 +24,7 @@
                         <h6 class="title title-top">@lang('profile.change_password')</h6>
                     </div>
                     <div class="ui-block-content">
-                        {!! Form::open(['class' => 'install-form', 'route' => 'survey.profile.changepassword', 'method' => 'post']) !!}
+                        {!! Form::open(['class' => 'install-form', 'id' => 'change-password', 'route' => 'survey.profile.changepassword', 'method' => 'post']) !!}
                             <div class="form-group row">
                                 {!! Form::label('oldpassword', trans('profile.old_password'), ['class' => 'col-sm-3 col-form-label-profile']) !!}
                                 <div class="col-sm-7">
@@ -34,13 +34,13 @@
                             <div class="form-group row">
                                 {!! Form::label('newpassword', trans('profile.new_password'), ['class' => 'col-sm-3 col-form-label-profile']) !!}
                                 <div class="col-sm-7">
-                                    {!! Form::password('newpassword', ['class' => 'form-control', 'required', 'placeholder' => trans('lang.password_placeholder')]) !!}
+                                    {!! Form::password('newpassword', ['class' => 'form-control', 'id' => 'newpassword', 'required', 'placeholder' => trans('lang.password_placeholder')]) !!}
                                 </div>
                             </div>
                             <div class="form-group row">
                                 {!! Form::label('retypepassword', trans('profile.re_type_password'), ['class' => 'col-sm-3 col-form-label-profile']) !!}
                                 <div class="col-sm-7">
-                                    {!! Form::password('retypepassword', ['class' => 'form-control', 'required', 'placeholder' => trans('lang.password_placeholder')]) !!}
+                                    {!! Form::password('retypepassword', ['class' => 'form-control', 'id' => 'retypepassword', 'required', 'placeholder' => trans('lang.password_placeholder')]) !!}
                                 </div>
                             </div>
                             <div class="form-group row">

--- a/resources/views/clients/profile/layout.blade.php
+++ b/resources/views/clients/profile/layout.blade.php
@@ -242,6 +242,7 @@
     {!! Html::script(asset(config('settings.plugins') . 'popper/popper.min.js')) !!}
     {!! Html::script(asset(config('settings.plugins') . 'bootstrap/dist/js/bootstrap.min.js')) !!}
     {!! Html::script(asset(config('settings.plugins') . 'datatables/js/jquery.dataTables.js')) !!}
+    {!! Html::script(asset(config('settings.plugins') . 'jquery-validation/jquery.validate.min.js')) !!}
     {!! Html::script(elixir(config('settings.public_template') . 'js/datatables-script.js')) !!}
     {!! Html::script(elixir(config('settings.public_template') . 'js/manage-invite.js')) !!}
     {!! Html::script(elixir(config('settings.public_template') . 'js/survey.js')) !!}


### PR DESCRIPTION
Summary : Should display error msg "Your password can not be started and ends with a space and required has letters, numbers, special characters." NEARBY textbox "New password" 
Step to reproduce:
1. Login in Fsurvey web 
2. Open "Profile" screen
3. Open "Account setting" 
4. Click on tab "Change password" 
5. Enter valid data into "Old password" textbox 
6. Enter "123456" into "New password" and "Re-type password" 
7. Click on button "Update" 
8. Focus error msg display in screen.
Actual result : Display error msg "Your password can not be started and ends with a space and required has letters, numbers, special characters." on top of page. 
Expected result : Should display error msg NEARBY textbox "New password" 

![image](https://user-images.githubusercontent.com/48110607/57437954-1290ec00-726d-11e9-85aa-9a71fccdfa92.png)

Redmine: https://edu-redmine.sun-asterisk.vn/issues/11702
