### PR TITLE
[Doing survey][Limit replies] NOT display correctly error msg when user do survey OVER LIMIT replies

### DIFF
--- a/app/Http/Middleware/DoingSurveyMiddleware.php
+++ b/app/Http/Middleware/DoingSurveyMiddleware.php
@@ -71,7 +71,9 @@ class DoingSurveyMiddleware
 
             if ($limitAnswer != config('settings.survey_setting.answer_unlimited') 
                 && $timesAnswer >= $limitAnswer) {
-                return  new Response(view('clients.survey.detail.complete', compact('title')));
+                $content = trans('lang.has_replied_the_maximum_number_of_limit_replies');
+
+                return  new Response(view('clients.survey.detail.complete', compact('title', 'content')));
             }
         }
 

--- a/resources/lang/en/lang.php
+++ b/resources/lang/en/lang.php
@@ -263,6 +263,7 @@ return [
     'export_error' => 'Export error!',
     'create_other' => 'Create other survey',
     'not_permission_to_doing_this_survey' => 'You do not have permission to doing this survey!',
+    'has_replied_the_maximum_number_of_limit_replies' => 'You has replied the maximum number of limit replies!',
 
     /*
         date time format

--- a/resources/lang/jp/lang.php
+++ b/resources/lang/jp/lang.php
@@ -262,6 +262,7 @@ return [
     'export_error' => 'Export error!',
     'create_other' => 'Create other survey',
     'not_permission_to_doing_this_survey' => 'You do not have permission to doing this survey!',
+    'has_replied_the_maximum_number_of_limit_replies' => 'You has replied the maximum number of limit replies!',
 
     /*
         date time format

--- a/resources/lang/vn/lang.php
+++ b/resources/lang/vn/lang.php
@@ -262,6 +262,7 @@ return [
     'export_error' => 'Lỗi khi tải xuống!',
     'create_other' => 'Tạo khảo sát khác',
     'not_permission_to_doing_this_survey' => 'Bạn không được phép thực hiện khảo sát này!',
+    'has_replied_the_maximum_number_of_limit_replies' => 'Bạn đã hết số lượt trả lời của khảo sát này!',
 
     /*
         date time format


### PR DESCRIPTION
Summary : System NOT display correctly error msg when The user has replied the maximum number of limit replies
Precondition: Have an account has replied the maximum number of limit replies
Step to reproduce : 
1. Open link doing survey with this account
2. Focus the msg display
Actual result : Display msg "Your answer has been recorded" 
Expected result : Display msg "You has replied the maximum number of limit replies" 

![Peek 2019-05-10 09-54](https://user-images.githubusercontent.com/48110607/57499701-d57b3700-730a-11e9-897a-17efddf5d365.gif)

https://edu-redmine.sun-asterisk.vn/issues/11821