### PR TITLE
Support #11823: [Register] Should confirm the email when the user registers the account

### DIFF
--- a/app/Http/Controllers/Auth/RegisterController.php
+++ b/app/Http/Controllers/Auth/RegisterController.php
@@ -8,7 +8,12 @@ use App\Http\Controllers\Controller;
 use Illuminate\Foundation\Auth\RegistersUsers;
 use App\Http\Requests\RegisterRequest;
 use App\Repositories\User\UserRepository;
+use App\Mail\Register;
 use Carbon\Carbon;
+use DB;
+use Exception;
+use Mail;
+use Session;
 
 class RegisterController extends Controller
 {
@@ -29,24 +34,48 @@ class RegisterController extends Controller
             'email',
             'password',
         ]);
-
         $input = [
             'name' => $data['name'],
             'email' => $data['email'],
             'password' => $data['password'],
             'level' => config('users.level.user'),
-            'status' => config('users.status.active'),
             'image' => config('setting.image_user_default'),
             'gender' => null,
+            'confirmation_code' => time().uniqid(true),
         ];
         $user = $this->userRepository->firstOrCreate($input);
-
         if ($user) {
-            Auth::login($user);
+            Mail::to($input['email'])->queue((new Register($input))->onConnection('database'));
 
             return response()->json(config('users.register_success'));
         }
 
         return response()->json(config('users.register_fail'));
+    }
+
+    public function confirmCode($code)
+    {
+        $user = $this->userRepository->where('confirmation_code', $code)->first();
+
+        if ($user) {
+            DB::beginTransaction();
+            try {
+                $updateUser = [
+                    'status' => config('users.status.active'),
+                    'confirmation_code' => null,
+                ];
+                $this->userRepository->update($user->id, $updateUser);
+                DB::commit();
+                Auth::login($user);
+
+                return redirect()->route('home');
+            } catch (Exception $e) {
+                DB::rollback();
+            }
+        } else {
+            Session::flash('confirmation-failed', trans('auth.confirmation_failed'));
+
+            return redirect()->route('home');
+        }
     }
 }

--- a/app/Mail/Register.php
+++ b/app/Mail/Register.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace App\Mail;
+
+use Illuminate\Bus\Queueable;
+use Illuminate\Mail\Mailable;
+use Illuminate\Queue\SerializesModels;
+use Illuminate\Contracts\Queue\ShouldQueue;
+
+class Register extends Mailable
+{
+    use Queueable, SerializesModels;
+
+    /**
+     * Create a new message instance.
+     *
+     * @return void
+     */
+    protected $data;
+
+    public function __construct($data)
+    {
+        $this->data = $data;
+    }
+
+    /**
+     * Build the message.
+     *
+     * @return $this
+     */
+    public function build()
+    {
+        return $this->view('clients.email.user.confirm-account')
+            ->subject(trans('email.active_account'))
+            ->with($this->data);
+    }
+}

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -31,6 +31,7 @@ class User extends Authenticatable
         'status',
         'level',
         'background',
+        'confirmation_code',
     ];
     /**
      * The attributes that should be hidden for arrays.

--- a/composer.json
+++ b/composer.json
@@ -37,7 +37,10 @@
         ],
         "files": [
             "app/Helpers/Helper.php"
-        ]
+        ],
+        "psr-4": {
+            "App\\": "app/"
+        }
     },
     "autoload-dev": {
         "classmap": [

--- a/database/migrations/2019_05_17_103041_add_confirmation_code_to_users_table.php
+++ b/database/migrations/2019_05_17_103041_add_confirmation_code_to_users_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class AddConfirmationCodeToUsersTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->string('confirmation_code')->after('status')->nullable();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->dropColumn('confirmation_code');
+        });
+    }
+}

--- a/database/migrations/2019_05_17_150334_edit_status_users_table.php
+++ b/database/migrations/2019_05_17_150334_edit_status_users_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class EditStatusUsersTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->smallInteger('status')->default(0)->change(); 
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->smallInteger('status')->change();
+        });
+    }
+}

--- a/resources/assets/templates/survey/js/auth.js
+++ b/resources/assets/templates/survey/js/auth.js
@@ -41,7 +41,8 @@ $(document).ready(function () {
         })
         .done(function (data) {
             if (data) {
-                location.reload();
+                $('#modalRegister').modal('hide');
+                $('#modalConfirm').modal('show');
             }
         })
         .fail(function (data) {
@@ -105,4 +106,23 @@ $(document).ready(function () {
     $(document).on('focus', '.reset-password-email', function () {
         $('.send-mail-fail').addClass('hidden');
     });
+
+    if ($('input[name="confirmation-failed"]').val()) {
+        $('#modalConfirm').find('.modal-content').empty();
+        $('#modalConfirm').find('.modal-content').append(`
+            <div class="modal-header text-center">
+                <h3 class="modal-title w-100 dark-grey-text font-weight-bold my-3" id="myModalLabel">
+                    <strong>${$('input[name="confirmation-failed"]').val()}</strong>
+                </h3>
+                <button type="button" class="close btn-close-form" data-dismiss="modal" aria-label="Close">
+                    <span aria-hidden="true">&times;</span>
+                </button>
+            </div>
+            <div class="modal-body mx-4">
+                <div class="text-center mb-3">
+                    ${Lang.get('lang.email_user_not_exist')}
+                </div>
+            </div>`);
+        $('#modalConfirm').modal('show');
+    }
 });

--- a/resources/lang/en/auth.php
+++ b/resources/lang/en/auth.php
@@ -18,4 +18,7 @@ return [
     'failed_password' => 'The password field is required.',
     'throttle' => 'Too many login attempts. Please try again in :seconds seconds.',
     'requrie_login' => 'You may login to create survey!',
+    'register_success' => 'Registration complete',
+    'confirmation_email' => 'Please checking your email to confirm your account!',
+    'confirmation_failed' => 'Registration failed',
 ];

--- a/resources/lang/en/email.php
+++ b/resources/lang/en/email.php
@@ -55,10 +55,12 @@ return [
     'share' => 'Share',
     'format_birthday_with_trans' => 'm-d-Y',
     'regards' => 'Regards',
-    'hello' => 'Hello!',
+    'hello' => 'Hello',
     'start_survey' => 'Start survey',
+    'active_account' => 'Active your account now!',
     'invite_email_subject' => 'Invite Survey',
     'manage_email_subject' => 'Manage Survey',
     'reminder_email_subject' => 'Reminder Survey',
+    'confirmation_register' => 'Your new account has been created. Please click button bellow to complete the registration!',
     'thank_you' => 'Thank you',
 ];

--- a/resources/lang/jp/auth.php
+++ b/resources/lang/jp/auth.php
@@ -18,4 +18,7 @@ return [
     'failed_password' => 'The password field is required.',
     'throttle' => 'Too many login attempts. Please try again in :seconds seconds.',
     'requrie_login' => 'You may login to create survey!',
+    'register_success' => 'Registration complete',
+    'confirmation_email' => 'Please checking your email to confirm your account!',
+    'confirmation_failed' => 'Registration failed',
 ];

--- a/resources/lang/jp/email.php
+++ b/resources/lang/jp/email.php
@@ -55,10 +55,12 @@ return [
     'share' => 'シェア',
     'format_birthday_with_trans' => 'm-d-Y',
     'regards' => 'Regards',
-    'hello' => 'Hello!',
+    'hello' => 'Hello',
     'start_survey' => 'Start survey',
+    'active_account' => 'Active your account now!',
     'invite_email_subject' => 'Invite Survey',
     'manage_email_subject' => 'Manage Survey',
     'reminder_email_subject' => 'Reminder Survey',
+    'confirmation_register' => 'あなたの新しいアカウントが作成されました。 下のボタンをクリックして登録を完了してください。',
     'thank_you' => 'Thank you',
 ];

--- a/resources/lang/vn/auth.php
+++ b/resources/lang/vn/auth.php
@@ -18,4 +18,7 @@ return [
     'failed_password' => 'Trường mật khẩu là bắt buộc.',
     'throttle' => 'Lần đăng nhập quá nhiều. Vui lòng thử lại :seconds Giây.',
     'requrie_login' => 'Bạn cần đăng nhập để bắt đầu với khảo sát đầu tiên!',
+    'register_success' => 'Đăng ký thành công',
+    'confirmation_email' => 'Vui lòng kiểm tra email để xác nhận tài khoản!',
+    'confirmation_failed' => 'Đăng ký thất bại',
 ];

--- a/resources/lang/vn/email.php
+++ b/resources/lang/vn/email.php
@@ -55,10 +55,12 @@ return [
     'share' => 'Chia sẻ',
     'format_birthday_with_trans' => 'd-m-Y',
     'regards' => 'Trân trọng',
-    'hello' => 'Xin chào!',
+    'hello' => 'Xin chào',
     'start_survey' => 'Bắt đầu',
+    'active_account' => 'Kích hoạt tài khoản',
     'invite_email_subject' => 'Mời khảo sát',
     'manage_email_subject' => 'Quản lý khảo sát',
     'reminder_email_subject' => 'Nhắc nhở khảo sát',
+    'confirmation_register' => 'Bạn nhận được email này vì đã đăng ký tài khoản FSurvey, vui lòng click vào nút dưới đây để hoàn tất đăng ký tài khoản!',
     'thank_you' => 'Thank you',
 ];

--- a/resources/views/clients/email/user/confirm-account.blade.php
+++ b/resources/views/clients/email/user/confirm-account.blade.php
@@ -1,0 +1,91 @@
+@php
+    $style = [
+        /* Layout ------------------------------ */
+
+        'body' => 'margin: 0; padding: 0; width: 100%; background-color: #F2F4F6;',
+        'email-wrapper' => 'width: 100%; margin: 0; padding: 0; background-color: #F2F4F6;',
+
+        /* Masthead ----------------------- */
+
+        'email-masthead' => 'padding: 25px 0; text-align: center;',
+        'email-masthead_name' => 'font-size: 16px; font-weight: bold; color: #2F3133; text-decoration: none; text-shadow: 0 1px 0 white;',
+
+        'email-body' => 'width: 100%; margin: 0; padding: 0; border-top: 1px solid #EDEFF2; border-bottom: 1px solid #EDEFF2; background-color: #FFF;',
+        'email-body_inner' => 'width: auto; max-width: 570px; margin: 0 auto; padding: 0;',
+        'email-body_cell' => 'padding: 35px;',
+
+        'email-footer' => 'width: auto; max-width: 570px; margin: 0 auto; padding: 0; text-align: center;background: #343d49',
+        'email-footer_cell' => 'color: #AEAEAE; padding: 35px; text-align: center;',
+
+        /* Body ------------------------------ */
+
+        'body_action' => 'width: 100%; margin: 30px auto; padding: 0; text-align: center;',
+        'body_sub' => 'margin-top: 25px; padding-top: 25px; border-top: 1px solid #EDEFF2;',
+
+        /* Type ------------------------------ */
+
+        'anchor' => 'color: #3869D4;',
+        'header-1' => 'margin-top: 0; color: #2F3133; font-size: 19px; font-weight: bold; text-align: left;',
+        'paragraph' => 'margin-top: 0; color: #74787E; font-size: 16px; line-height: 1.5em;',
+        'title-survey' => 'margin-top: 0; color: #19c4d0; line-height: 1.5em; text-align: center; font-size: 30px; text-shadow: 2px 2px 2px #5f797d; margin-bottom: 0.5em; font-weight: bold;',
+        'paragraph-sub' => 'margin-top: 0; color: #74787E; font-size: 12px; line-height: 1.5em;',
+        'paragraph-center' => 'text-align: center;',
+
+        /* Buttons ------------------------------ */
+
+        'button' => 'display: block; display: inline-block; width: 200px; min-height: 20px; padding: 10px;
+                    background-color: #3869D4; border-radius: 3px; color: #ffffff; font-size: 15px; line-height: 25px;
+                    text-align: center; text-decoration: none; -webkit-text-size-adjust: none;',
+
+        'button--green' => 'background-color: #22BC66;',
+        'button--red' => 'background-color: #dc4d2f;',
+        'button--blue' => 'background-color: #3869D4;',
+    ];
+    $fontFamily = 'font-family: Arial, \'Helvetica Neue\', Helvetica, sans-serif;';
+@endphp
+
+@extends('clients.email.layout.master')
+@section('content')
+    @foreach (config('settings.locale') as $lang)
+        <tr>
+            <td style="{{ $style['email-body'] }}" width="100%">
+                <table style="{{ $style['email-body_inner'] }}" align="center" width="570" cellpadding="0" cellspacing="0">
+                    <tr>
+                        <td style="{{ $fontFamily }} {{ $style['email-body_cell'] }}">
+                            <!-- Greeting -->
+                            <h1 style="{{ $style['header-1'] }}">
+                                {{ Lang::choice('email.hello', 0, [], $lang) }}
+                                {{ ucfirst($name) }} !
+                            </h1>
+
+                            <!-- Intro -->
+                            <p style="{{ $style['paragraph'] }}">
+                                {{ Lang::choice('email.confirmation_register', 0, [], $lang) }}
+                            </p>
+
+                            <!-- Action Button -->
+                            <table style="{{ $style['body_action'] }}" align="center" width="100%" cellpadding="0" cellspacing="0">
+                                <tr>
+                                    <td align="center">
+                                        <a href="{{ route('confirmation-register', ucfirst($confirmation_code)) }}"
+                                            style="{{ $fontFamily }} {{ $style['button'] }} {{ $style['button--blue'] }}"
+                                            class="button"
+                                            target="_blank">
+                                            {{ Lang::choice('email.active_account', 0, [], $lang) }}
+                                        </a>
+                                    </td>
+                                </tr>
+                            </table>
+
+                            <!-- Salutation -->
+                            <p style="{{ $style['paragraph'] }}">
+                                {{ Lang::choice('email.regards', 0, [], $lang) }},<br>{{ config('settings.fsurvey') }}
+                            </p>
+                        </td>
+                    </tr>
+                </table>
+            </td>
+        </tr>
+        <hr>
+    @endforeach
+@endsection

--- a/resources/views/clients/home/index.blade.php
+++ b/resources/views/clients/home/index.blade.php
@@ -13,6 +13,9 @@
             'class' => 'btn-show-pupup-login',
         ]) }}
     @endif
+    @if (Session::has('confirmation-failed'))
+        {!! Form::hidden('confirmation-failed', Session::get('confirmation-failed')) !!}
+    @endif
     <main class="site-main">
         <div id="home" class="section block-primary align-c">
             <div id="siteBg" class="site-bg">

--- a/resources/views/clients/layout/master.blade.php
+++ b/resources/views/clients/layout/master.blade.php
@@ -6,6 +6,7 @@
     @include('clients.user.auth.register')
     @include('clients.user.auth.login')
     @include('clients.user.auth.forgot-password')
+    @include('clients.user.auth.confirm-password')
 @endif
 @include('clients.feedback.create')
 @include('clients.layout.footer')

--- a/resources/views/clients/user/auth/confirm-password.blade.php
+++ b/resources/views/clients/user/auth/confirm-password.blade.php
@@ -1,0 +1,19 @@
+<div class="modal fade" id="modalConfirm" tabindex="-1" role="dialog" aria-labelledby="myModalLabel">
+    <div class="modal-dialog" role="document">
+        <div class="modal-content form-elegant">
+            <div class="modal-header text-center">
+                <h3 class="modal-title w-100 dark-grey-text font-weight-bold my-3" id="myModalLabel">
+                    <strong>@lang('auth.register_success')</strong>
+                </h3>
+                <button type="button" class="close btn-close-form" data-dismiss="modal" aria-label="Close">
+                    <span aria-hidden="true">&times;</span>
+                </button>
+            </div>
+            <div class="modal-body mx-4">
+                <div class="text-center mb-3">
+                    @lang('auth.confirmation_email')
+                </div>
+            </div>
+        </div>
+    </div>
+</div>

--- a/routes/web.php
+++ b/routes/web.php
@@ -309,6 +309,8 @@ Route::group(['namespace' => 'Auth'], function () {
 
     Route::post('register', 'RegisterController@register')->name('register');
 
+    Route::get('confirmation-register/{code}', 'RegisterController@confirmCode')->name('confirmation-register');
+
     Route::get('logout', 'LoginController@logout')->name('logout');
 
     Route::post('reset-password', 'ForgotPasswordController@sendMailResetPassword')->name('send-mail-reset-password');


### PR DESCRIPTION
Summary : Should confirm the email when the user registers the account

Step to reproduce : 
1. Open register screen
2. input with valid data
3. Click on register button

Actual result : 
- Registration success.
- Login to fsurvey with the account you just created

Expected result :
1. Registration success and display message: " Đăng ký thành công. Để hoàn thiện, bạn cần kích hoạt tài khoản trong email của bạn" 
2. Set user status: "Chưa kích hoạt" 
3. In the confirmation email, there is an activation link. After the user clicks on the link, return to Fsurvey's home page and display the message: "Bạn đã kích hoạt tài khoản thành công" 
4.Set the user's status "Kích hoạt" and allow execution with Fsurvey functions.
![image](https://user-images.githubusercontent.com/48110607/58106254-019f8d80-7c12-11e9-8fb9-5de654c75858.png)
![image](https://user-images.githubusercontent.com/48110607/58106316-209e1f80-7c12-11e9-9cae-9bc0c2a3233f.png)

https://edu-redmine.sun-asterisk.vn/issues/11823

