### PR TITLE
[GUI][Create survey] Display the upper and lower spacing of the two fields is too big for the linear scale question

### DIFF
--- a/resources/assets/templates/survey/css/form-builder-custom.css
+++ b/resources/assets/templates/survey/css/form-builder-custom.css
@@ -1374,6 +1374,11 @@ nav ul a:hover {
     background-color: #f1f1f1;
     border-radius: 4px !important;
     margin-top: 2px;
+    width: 105%;
+}
+
+.option-linear-scale {
+    margin-right: 2%;
 }
 
 .survey-select-styled:after {

--- a/resources/assets/templates/survey/js/builder-custom.js
+++ b/resources/assets/templates/survey/js/builder-custom.js
@@ -1109,7 +1109,8 @@ jQuery(document).ready(function () {
             } else {
                 $('#end-time-error').empty();
             }
-            $('.form-row').css('margin-bottom', '3rem');
+            $('.form-row').css('margin-bottom', '1rem');
+            $('.form-group.form-row').css('margin-bottom', '3rem');
         }
     });
 

--- a/resources/views/clients/survey/elements/master.blade.php
+++ b/resources/views/clients/survey/elements/master.blade.php
@@ -56,7 +56,7 @@
                     </li>
                     <li data-type="{{ config('settings.question_type.linear_scale') }}" data-url="{{ route('ajax-fetch-linear-scale-question') }}" class="clearfix">
                         <span>{{ Html::image(asset(config('settings.linear_scale_icon')), null, ['class' => 'linear-scale']) }}</span>
-                        <span class="option-menu-content">@lang('lang.linear_scale')</span>
+                        <span class="option-menu-content option-linear-scale">@lang('lang.linear_scale')</span>
                     </li>
                 </ul>
             </div>


### PR DESCRIPTION
Summary: Display the upper and lower spacing of the two fields is too big for the linear scale question

Step to reproduce: 
1. Open the create survey screen
2. Create question with linear scale question
3. Click on linear scale 
4. Observe the screen

Actual result: Display the upper and lower spacing of the two fields is too big for the linear scale question

