### PR TITLE
Support #12339: [Profile screen][Account Setting][Change password] Should display message error: "Wrong old password!" NEARBY "Old password" textbox

### DIFF
--- a/app/Http/Controllers/Survey/ProfileController.php
+++ b/app/Http/Controllers/Survey/ProfileController.php
@@ -159,26 +159,23 @@ class ProfileController extends Controller
 
             if (!Hash::check($request->oldpassword, $user->password)) {
                 $error = trans('profile.password_wrong');
-                throw new Exception('Old password wrong');
-            }
-
-            if ($request->newpassword != $request->retypepassword) {
-                $error = trans('profile.password_confirm_wrong');
-                throw new Exception('Password confirm wrong!');
+                
+                return response()->json([
+                    'success' => false, 
+                    'error' => $error
+                ]);
             }
 
             $updateData['password'] = $request->newpassword;
             $this->userRepository->updateUser($user, $updateData);
             Session::flash('success', trans('profile.edit_success'));
+
+            return response()->json([
+                'success' => true,
+            ]);
         } catch (Exception $e) {
-            if (!isset($error)) {
-                $error = trans('profile.edit_error');
-            }
-
-            Session::flash('error', $error);
+            return redirect()->back()->with('error', trans('profile.edit_error'));
         }
-
-        return redirect()->back();
     }
 
     public function changeAvatar(UpdateImageRequest $request)

--- a/resources/assets/templates/survey/js/auth.js
+++ b/resources/assets/templates/survey/js/auth.js
@@ -102,7 +102,29 @@ $(document).ready(function () {
             $('.email-reset-messages').text(errors.email);
         });
     });
+    $(document).on('submit', '#change-password', function (e) {
+        e.preventDefault();
+        $.ajax({
+            method: $(this).attr('method'),
+            url: $(this).attr('action'),
+            data: $(this).serialize(),
+            dataType: 'json'
+        })
+        .done(function (data) {
+            if (data.success) {
+                location.reload();
+            } else {
+                $('.change-password-messages').text(data.error);
+                $('#oldpassword').css('border-color', 'red');
+            }
+        })
+    });
 
+    $(document).on('focus', '#oldpassword', function () {
+        $('.change-password-messages').text('');
+        $('#oldpassword').css('border-color', '#ced4da');
+    });
+    
     $(document).on('focus', '.reset-password-email', function () {
         $('.send-mail-fail').addClass('hidden');
     });

--- a/resources/lang/vn/profile.php
+++ b/resources/lang/vn/profile.php
@@ -12,7 +12,7 @@ return [
     'edit_error' => 'Thay đổi thất bại!',
     'edit_success' => 'Thay đổi thành công!',
     'password_confirm_wrong' => 'Sai mật khẩu xác nhận!',
-    'password_wrong' => 'Sai mật khẩu cũ!',
+    'password_wrong' => 'Mật khẩu cũ không đúng!',
     'change' => 'Thay đổi',
     'male' => 'Nam',
     'female' => 'Nữ',

--- a/resources/views/clients/profile/changepassword.blade.php
+++ b/resources/views/clients/profile/changepassword.blade.php
@@ -28,7 +28,13 @@
                             <div class="form-group row">
                                 {!! Form::label('oldpassword', trans('profile.old_password'), ['class' => 'col-sm-3 col-form-label-profile']) !!}
                                 <div class="col-sm-7">
-                                    {!! Form::password('oldpassword', ['class' => 'form-control', 'required', 'placeholder' => trans('lang.password_placeholder')]) !!}
+                                    {!! Form::password('oldpassword', [
+                                        'id' => 'oldpassword',
+                                        'class' => 'form-control',
+                                        'required',
+                                        'placeholder' => trans('lang.password_placeholder'),
+                                        ]) !!}
+                                    <span class="error change-password-messages"></span>
                                 </div>
                             </div>
                             <div class="form-group row">


### PR DESCRIPTION
Summary: Should display message error: "Wrong old password!" NEARBY "Old password" textbox

Step to reproduce: 
1. Open the change password screen
2. Input wrong old password
3. Input the correct new password and re-type password
4. Press "Update" button
5. Observe the screen

Actual result :
Display message error: "wrong old password!" on top of page

Expected result : 
Should display message error: "Wrong old password!" NEARBY "Old password" textbox

![image](https://user-images.githubusercontent.com/48110607/58411075-b10ab300-809d-11e9-9fcd-95f3b7c5a9f4.png)


https://edu-redmine.sun-asterisk.vn/issues/12339