### PR TITLE
Bug #12707: [Result survey] Do NOT display the chart result for linear scale question in redirect question

### DIFF
--- a/resources/assets/templates/survey/js/result.js
+++ b/resources/assets/templates/survey/js/result.js
@@ -401,4 +401,11 @@ function subResults() {
 
         createPieChart($(this).attr('id'), dataMultipleChoice);
     });
+
+    $('.sub-linearscale-result').each(function() {
+        var text = createDataLinrearForChart($(this).attr('data'));
+        var dataLinearScale = $.parseJSON(text);
+
+        createBarChartColumn($(this).attr('id'), dataLinearScale);
+    });
 }

--- a/resources/views/clients/survey/result/redirect_result.blade.php
+++ b/resources/views/clients/survey/result/redirect_result.blade.php
@@ -71,6 +71,20 @@
                                 </p>
                             @endforeach
                         </div>
+                    @elseif ($result['question_type'] == config('settings.question_type.linear_scale'))
+                        <div class="answer-result chart-result-answer sub-linearscale-result"
+                            id="{{ $result['question']->id }}"
+                            data="{{ json_encode($result['answers']) }}"
+                            data-linear="{{ json_encode($result['question']->setting_value) }}">
+                        </div>
+                        <span class="linear-min">
+                            {{ $result['question']->setting_value->min_value }} :
+                            {{ $result['question']->setting_value->min_content }}
+                        </span>
+                        <span class="linear-max">
+                            {{ $result['question']->setting_value->max_value }} :
+                            {{ $result['question']->setting_value->max_content }}
+                        </span>
                     @elseif ($result['question_type'] == config('settings.question_type.multiple_choice'))
                         @if ($result['question']->answers->count())
                             <div class="answer-result sub-multiple-choice-result"


### PR DESCRIPTION
Summary: Do NOT display the chart result for linear scale question in redirect question

Step to reproduce:
1. Open the result survey
2. Choose the summary result
3. Observe the result of linear scale in redirect question

Actual result: Do NOT display the chart result for linear scale question in redirect question

Expected: Display the chart result for linear scale question in redirect question
![Peek 2019-05-31 11-25](https://user-images.githubusercontent.com/48110607/58681505-dbf35080-8396-11e9-985d-77bac93ba976.gif)
