### PR TITLE
Bug #13127: [Edit survey] Do NOT edit survey when user re-load of the edit page

### DIFF
--- a/app/Http/Controllers/SurveyController.php
+++ b/app/Http/Controllers/SurveyController.php
@@ -328,7 +328,7 @@ class SurveyController extends Controller
         $survey = $this->surveyRepository->getSurveyByTokenManage($tokenManage);
 
         if (Auth::user()->cannot('edit', $survey)) {
-            return view('clients.layout.404');
+            return redirect()->route('survey.survey.show-surveys')->with('error', trans('lang.confirm_close_to_edit'));
         }
 
         if (!$survey) {


### PR DESCRIPTION
Summary: Do NOT edit survey when user re-load of the edit page

Step to reproduce:
1. Open the edit screen
2. Edit survey
3. Send survey
4. Click to go back
5. Press F5
6. Observe the screen

Actual result: 
4. Return to the survey page before editing 
5. Error 404

Expected result: 
4. Return to the survey page after editing
5. Reload successfully

https://edu-redmine.sun-asterisk.vn/issues/13127