### PR TITLE
[Edit survey] Do not display menu bar of section in grid question

### DIFF
--- a/resources/views/clients/survey/edit/elements/grid.blade.php
+++ b/resources/views/clients/survey/edit/elements/grid.blade.php
@@ -48,3 +48,4 @@
         </span>
     </div>
 </div>
+@include('clients.survey.edit.elements.element-footer')

--- a/resources/views/clients/survey/edit/elements/linear_scale.blade.php
+++ b/resources/views/clients/survey/edit/elements/linear_scale.blade.php
@@ -1,29 +1,30 @@
 @include('clients.survey.edit.elements.element-header')
-    <div class="col-12 linear-scale-block" data-question-id="{{ $question->id }}">
-        <div class="form-row">
-            <div class="col-2 min-value">
-                {!! Form::hidden("min_value_hidden_$question->id", $question->setting_value->min_value) !!}
-                {!! Form::select("min_value_$question->id", [], null, ['class' => "form-control min-value-$question->id"]) !!}
-            </div>
-            <span class="padding-10">{{ trans('lang.to') }}</span>
-            <div class="col-2">
-                {!! Form::hidden("max_value_hidden_$question->id", $question->setting_value->max_value) !!}
-                {!! Form::select("max_value_$question->id", [], null, ['class' => "form-control max-value-$question->id"]) !!}
-            </div>
+<div class="col-12 linear-scale-block" data-question-id="{{ $question->id }}">
+    <div class="form-row">
+        <div class="col-2 min-value">
+            {!! Form::hidden("min_value_hidden_$question->id", $question->setting_value->min_value) !!}
+            {!! Form::select("min_value_$question->id", [], null, ['class' => "form-control min-value-$question->id"]) !!}
         </div>
-        <br>
-        <div class="form-row">
-            <label for="min-content-{{ $question->id }}" class="col-1 min-content-{{ $question->id }} padding-10"></label>
-            {!! Form::text("min_content_$question->id", $question->setting_value->min_content, [
-                'class' => "col-5 form-control min-content-$question->id",
-                'placeholder' => trans('lang.label_option')
-            ]) !!}
-        </div>
-        <div class="form-row">
-            <label for="max-content-{{ $question->id }}" class="col-1 max-content-{{ $question->id }} padding-10"></label>
-            {!! Form::text("max_content_$question->id", $question->setting_value->max_content, [
-                'class' => "col-5 form-control max-content-$question->id",
-                'placeholder' => trans('lang.label_option')
-            ]) !!}
+        <span class="padding-10">{{ trans('lang.to') }}</span>
+        <div class="col-2">
+            {!! Form::hidden("max_value_hidden_$question->id", $question->setting_value->max_value) !!}
+            {!! Form::select("max_value_$question->id", [], null, ['class' => "form-control max-value-$question->id"]) !!}
         </div>
     </div>
+    <br>
+    <div class="form-row">
+        <label for="min-content-{{ $question->id }}" class="col-1 min-content-{{ $question->id }} padding-10"></label>
+        {!! Form::text("min_content_$question->id", $question->setting_value->min_content, [
+            'class' => "col-5 form-control min-content-$question->id",
+            'placeholder' => trans('lang.label_option')
+        ]) !!}
+    </div>
+    <div class="form-row">
+        <label for="max-content-{{ $question->id }}" class="col-1 max-content-{{ $question->id }} padding-10"></label>
+        {!! Form::text("max_content_$question->id", $question->setting_value->max_content, [
+            'class' => "col-5 form-control max-content-$question->id",
+            'placeholder' => trans('lang.label_option')
+        ]) !!}
+    </div>
+</div>
+@include('clients.survey.edit.elements.element-footer')


### PR DESCRIPTION
Summary: Do not display menu bar of section in grid question

Step reproduce:
1. Open edit survey
2. Click on grid question
3. Observe the screen

Actual result: Do not display menu bar of section in grid question

Expected result: 
- Display menu bar of section in grid question

https://edu-redmine.sun-asterisk.vn/issues/13237