### PR TITLE
Bug #13415: [Create survey][Grid question] Do not display message error when input text field with 256 character AND Bug #13418: [Doing survey][Grid question] Display layout incorrectly when input "Row" text field with 255 character

### DIFF
--- a/config/settings.php
+++ b/config/settings.php
@@ -357,4 +357,5 @@ return [
     'path_backup_data' => 'app/backup_data',
     'number_day_backup' => 7,
     'linear_scale_icon' => '/templates/survey/images/linear_scale.png',
+    'limit_grid' => 15, 
 ];

--- a/resources/assets/templates/survey/js/builder-custom.js
+++ b/resources/assets/templates/survey/js/builder-custom.js
@@ -1420,12 +1420,14 @@ jQuery(document).ready(function () {
         $(`#question_${questionId} .sub-question-input`).each(function () {
             $(this).rules('add', {
                 required: true,
+                maxlength: 255,
             });
         });
 
         $(`#question_${questionId} .sub-question-option`).each(function () {
             $(this).rules('add', {
                 required: true,
+                maxlength: 255,
             });
         });
     }

--- a/resources/views/clients/survey/create/elements-preview/grid.blade.php
+++ b/resources/views/clients/survey/create/elements-preview/grid.blade.php
@@ -1,19 +1,19 @@
 <div class="item-answer">
     <div class="grid-container">
-        <div class="{{ count($question->subOptions) > config('settings.number_2') ? "grid-scroll" : "" }}">
+        <div class="{{ count($question->subOptions) > config('settings.number_2') ? 'grid-scroll' : '' }}">
             <div class="grid-head">
                 <div class="grid-colum-head">
                     <div class="grid-first-colum none-colum"></div>
                     @foreach ($question->subOptions as $option)
-                        <div class="grid-colum {{ count($question->subOptions) > config('settings.number_2') ? "multiple-option" : "" }}">{{$option}}</div>  
+                        <div class="grid-colum {{ count($question->subOptions) > config('settings.number_2') ? "multiple-option" : "" }}">{{$option}}</div>
                     @endforeach
                 </div>
                 @foreach ($question->subQuestions as $subQuestion)
                     <div class="grid-row">
                         <span class="grid-row-span">
-                        <div class="grid-first-colum">{{$subQuestion}}</div>
+                        <div class="grid-first-colum" title="{{ $subQuestion }}">{{ str_limit($subQuestion, config('settings.limit_grid')) }}</div>
                             @foreach ($question->subOptions as $option)
-                                <div class="grid-colum {{ count($question->subOptions) > config('settings.number_2') ? "multiple-option" : "" }}">
+                                <div class="grid-colum {{ count($question->subOptions) > config('settings.number_2') ? 'multiple-option' : '' }}">
                                     <label class="container-radio-setting-survey">
                                         {!! Form::radio('answer_' . $loop->parent->iteration, '', false, [
                                             'class' => 'radio-answer-preview',

--- a/resources/views/clients/survey/detail/elements/grid.blade.php
+++ b/resources/views/clients/survey/detail/elements/grid.blade.php
@@ -1,6 +1,6 @@
 <div class="item-answer">
     <div class="grid-container">
-        <div class="{{ count($question->sub_options) > config('settings.number_2') ? "grid-scroll" : "" }}">
+        <div class="{{ count($question->sub_options) > config('settings.number_2') ? 'grid-scroll' : '' }}">
             <div class="grid-head">
                 <div class="grid-colum-head">
                     <div class="grid-first-colum none-colum"></div>
@@ -11,9 +11,9 @@
                 @foreach ($question->sub_questions as $subQuestion)
                 <div class="grid-row">
                     <span class="grid-row-span">
-                    <div class="grid-first-colum" data-row-index="{{ $loop->iteration }}">{{$subQuestion}}</div>
+                    <div class="grid-first-colum" data-row-index="{{ $loop->iteration }}" title="{{ $subQuestion }}">{{ str_limit($subQuestion, config('settings.limit_grid')) }}</div>
                         @foreach ($question->sub_options as $option)
-                            <div class="grid-colum {{ count($question->sub_options) > config('settings.number_2') ? "multiple-option" : "" }}">
+                            <div class="grid-colum {{ count($question->sub_options) > config('settings.number_2') ? 'multiple-option' : '' }}">
                                 <label class="container-radio-setting-survey" data-col-index="{{ $loop->iteration }}">
                                     {!! Form::radio('answer_' . $loop->parent->iteration, '', false, [
                                         'class' => 'radio-answer-preview',

--- a/resources/views/clients/survey/result/elements/grid.blade.php
+++ b/resources/views/clients/survey/result/elements/grid.blade.php
@@ -6,13 +6,13 @@
                 <div class="grid-colum-head">
                     <div class="grid-first-colum none-colum"></div>
                     @foreach ($question->sub_options as $option)
-                        <div class="grid-colum">{{$option}}</div>  
+                        <div class="grid-colum">{{$option}}</div>
                     @endforeach
                 </div>
                 @foreach ($question->sub_questions as $subQuestion)
                 <div class="grid-row">
                     <span class="grid-row-span">
-                    <div class="grid-first-colum">{{$subQuestion}}</div>
+                    <div class="grid-first-colum" title="{{ $subQuestion }}">{{ str_limit($subQuestion, config('settings.limit_grid')) }}</div>
                         @foreach ($question->sub_options as $option)
                             <div class="grid-colum">
                                 <label class="container-radio-setting-survey">


### PR DESCRIPTION
Summary: Display layout for grid question incorrectly when input "Row" text field with 255 character

Pre-condition: input "Row" text field for grid question with 255 character when create survey

Step to reproduce:
1. Open doing survey
2. Observe grid question

Actual result: 
Display layout for grid question incorrectly when input "Row" text field with 255 character

Expected result: 
- Display layout for grid question correctly
- Display tooltip with content of row
![bug](https://user-images.githubusercontent.com/48110607/59411926-9303b900-8de6-11e9-890f-73a3377201bb.jpg)

---------------------------------------------------------

Summary: Do not display message error when input text field with 256 character in grid question

Step to reproduce: 
1. Open create survey
2. Choose grid question
3. Input "Row" text field = 256 character
4. Observe the screen

Actual result: 
Do not display message error: "Please enter no more than 255 characters."

Expected result: 
Display message error: "Please enter no more than 255 characters."

![image](https://user-images.githubusercontent.com/48110607/59411813-52a43b00-8de6-11e9-87da-5c740dde4850.png)

