### PR TITLE
Edit answer for grid question and Fix Bug #13518: [Result survey][Grid question] Do NOT display full column in personal result

### DIFF
--- a/resources/views/clients/survey/result/edit-answer/elements/grid.blade.php
+++ b/resources/views/clients/survey/result/edit-answer/elements/grid.blade.php
@@ -17,6 +17,8 @@
                                 <label class="container-radio-setting-survey" data-col-index="{{ $loop->iteration }}">
                                     {!! Form::radio('answer_' . $loop->parent->iteration, '', false, [
                                         'class' => 'radio-answer-preview',
+                                        ($result->array_content[$loop->parent->iteration] != ''
+                                        && $result->array_content[$loop->parent->iteration] == $loop->iteration) ? 'checked' : '',
                                     ]) !!}
                                     <span class="checkmark-radio"></span>
                                 </label>

--- a/resources/views/clients/survey/result/elements/grid.blade.php
+++ b/resources/views/clients/survey/result/elements/grid.blade.php
@@ -1,21 +1,20 @@
 <div class="item-answer">
     <div class="grid-container">
-
-        <div class="grid-scroll">
+        <div class="{{ count($question->sub_options) > config('settings.number_2') ? 'grid-scroll' : '' }}">
             <div class="grid-head">
                 <div class="grid-colum-head">
                     <div class="grid-first-colum none-colum"></div>
                     @foreach ($question->sub_options as $option)
-                        <div class="grid-colum">{{$option}}</div>
+                        <div class="grid-colum {{ count($question->sub_options) > config('settings.number_2') ? 'multiple-option' : '' }}">{{$option}}</div>
                     @endforeach
                 </div>
                 @foreach ($question->sub_questions as $subQuestion)
                 <div class="grid-row">
                     <span class="grid-row-span">
-                    <div class="grid-first-colum" title="{{ $subQuestion }}">{{ str_limit($subQuestion, config('settings.limit_grid')) }}</div>
+                    <div class="grid-first-colum" data-row-index="{{ $loop->iteration }}" title="{{ $subQuestion }}">{{ str_limit($subQuestion, config('settings.limit_grid')) }}</div>
                         @foreach ($question->sub_options as $option)
-                            <div class="grid-colum">
-                                <label class="container-radio-setting-survey">
+                            <div class="grid-colum {{ count($question->sub_options) > config('settings.number_2') ? 'multiple-option' : '' }}">
+                                <label class="container-radio-setting-survey" data-col-index="{{ $loop->iteration }}">
                                     {!! Form::radio('answer_' . $loop->parent->iteration, '', false, [
                                         'class' => 'radio-answer-preview',
                                         ($detailResult->array_content[$loop->parent->iteration] != ''


### PR DESCRIPTION
Summary: Do NOT display full column in personal result

Step to result: 
1. Open personal result 
2. Observe grid question

Actual result: Do NOT display full column in personal result

Expected result: Display full column in personal result

![Peek 2019-06-14 08-54](https://user-images.githubusercontent.com/48110607/59478208-bbd98c00-8e82-11e9-87a7-bdb42b1561a5.gif)
