### PR TITLE
[Export survey] Do not display full section for redirect question

### DIFF
--- a/app/Repositories/Survey/SurveyRepository.php
+++ b/app/Repositories/Survey/SurveyRepository.php
@@ -843,9 +843,16 @@ class SurveyRepository extends BaseRepository implements SurveyInterface
                 }
             }
 
+            //get section by redirect_id
+            $sections = $survey->sections->where('redirect_id', $answer->id);
+            $section_id = [];
+            foreach ($sections as $section) {
+                array_push($section_id, $section->id);
+            }
+
             //get question by case
             $questionsInsideRedirectSection = app(QuestionInterface::class)->withTrashed()
-                ->whereIn('section_id', $survey->sections->where('redirect_id', $answer->id)->first()->id)
+                ->whereIn('section_id', $section_id)
                 ->with('settings', 'section')->get();
             $questions = $questionsWithoutRedirect->merge($questionsInsideRedirectSection)->sortBy('order')->sortBy('section_order');
 


### PR DESCRIPTION
Summary: Do not display full section for redirect question

Pre-condition: Created survey many section and executed survey

Step to reproduce: 
1. Open result survey
2. Click on download the answer
3. Open export file 
4. Observe

Actual result: 
- Do not display full section for redirect question

Expected result: 
- Display full section for redirect question