### PR TITLE
Bug #13901: [Create survey] Display message error when user create 2 grid question that content of row/column duplicate

### DIFF
--- a/resources/assets/templates/survey/js/builder-custom.js
+++ b/resources/assets/templates/survey/js/builder-custom.js
@@ -116,8 +116,8 @@ jQuery(document).ready(function () {
             <span class="row-column-content">
                 <div class="sub-question-content">
                     <label for="sub-question" class="col-1 row-index sub-question">${++index}</label>
-                    <input type="text" name="sub-question-${index}" value="${Lang.get('lang.row')} ${index}"
-                        class="col-5 form-control sub-question-input" row-question="row-question-index-${index}" />
+                    <input type="text" name="sub-question-${questionId}-${index}" value="${Lang.get('lang.row')} ${index}"
+                        class="col-5 form-control sub-question-input" row-question="row-question-${questionId}-index-${index}" />
                     <div class="delete-row fa fa-times"></div>
                 </div>
             </span>
@@ -136,8 +136,8 @@ jQuery(document).ready(function () {
             <span class="row-column-content">
                 <div class="sub-question-content">
                     <span class="col-1 fa fa-circle-o column-icon" data-index="${++index}"></span>
-                    <input type="text" name="sub-question-option-${index}" value="${Lang.get('lang.column')} ${index}"
-                        class="col-5 form-control sub-question-option" col-value="col-value-index-${index}"/>
+                    <input type="text" name="sub-question-option-${questionId}-${index}" value="${Lang.get('lang.column')} ${index}"
+                        class="col-5 form-control sub-question-option" col-value="col-value-${questionId}-index-${index}"/>
                     <div class="delete-column fa fa-times"></div>
                 </div>
             </span>
@@ -1386,11 +1386,12 @@ jQuery(document).ready(function () {
 
     // sub question unique rule for grid question
     $.validator.addMethod('subquestionunique', function (value, element) {
-        var parentForm = $(element).closest('form');
+        var parentForm = $(element).closest('.list-of-row-column');
+        var questionId = $(parentForm).closest('li.form-line').data('question-id');
         var timeRepeated = 0;
 
         if (value.trim()) {
-            $(parentForm.find('li.form-line.sort div.form-row input:regex(row-question, row-question-index-*)')).each(function () {
+            $(parentForm.find(`input:regex(row-question, ^row-question-${questionId}-index-.*$)`)).each(function () {
                 if ($(this).val() === value) {
                     timeRepeated++;
                 }
@@ -1403,11 +1404,12 @@ jQuery(document).ready(function () {
 
     // sub option unique rule for grid question
     $.validator.addMethod('suboptionunique', function (value, element) {
-        var parentForm = $(element).closest('form');
+        var parentForm = $(element).closest('.list-of-row-column');
+        var questionId = $(parentForm).closest('li.form-line').data('question-id');
         var timeRepeated = 0;
 
         if (value.trim()) {
-            $(parentForm.find('li.form-line.sort div.form-row input:regex(col-value, col-value-index-*)')).each(function () {
+            $(parentForm.find(`input:regex(col-value, ^col-value-${questionId}-index-.*$)`)).each(function () {
                 if ($(this).val() === value) {
                     timeRepeated++;
                 }
@@ -1457,7 +1459,7 @@ jQuery(document).ready(function () {
 
     // add validation rule for row and column of grid question
     function addValidationRuleForRowAndColumn(questionId) {
-        $(`#question_${questionId} .sub-question-input`).each(function () {
+        $(`#question_${questionId} input:regex(row-question, ^row-question-${questionId}-index-.*$)`).each(function () {
             $(this).rules('add', {
                 required: true,
                 maxlength: 255,
@@ -1465,7 +1467,7 @@ jQuery(document).ready(function () {
             });
         });
 
-        $(`#question_${questionId} .sub-question-option`).each(function () {
+        $(`#question_${questionId} input:regex(col-value, ^col-value-${questionId}-index-.*$)`).each(function () {
             $(this).rules('add', {
                 required: true,
                 maxlength: 255,

--- a/resources/views/clients/survey/elements/grid.blade.php
+++ b/resources/views/clients/survey/elements/grid.blade.php
@@ -10,9 +10,9 @@
                         <label for="sub-question" class="col-1 row-index sub-question">
                             {{ config('settings.number_1') }}
                         </label>
-                        {!! Form::text("sub-question-" . config('settings.number_1'), trans('lang.row') . " " . config('settings.number_1'), [
+                        {!! Form::text("sub-question-$questionId-" . config('settings.number_1'), trans('lang.row') . " " . config('settings.number_1'), [
                             'class' => "col-5 form-control sub-question-input",
-                            'row-question' => 'row-question-index-' . config('settings.number_1'),
+                            'row-question' => "row-question-$questionId-index-" . config('settings.number_1'),
                         ]) !!}
                         <div class="delete-row fa fa-times"></div>
                     </div>
@@ -31,9 +31,9 @@
                     <div class="sub-question-content">
                         <span class="col-1 fa fa-circle-o column-icon" data-index="{{ config('settings.number_1') }}">
                         </span>
-                        {!! Form::text("sub-question-option-" . config('settings.number_1'), trans('lang.column') . " " . config('settings.number_1'), [
+                        {!! Form::text("sub-question-option-$questionId-" . config('settings.number_1'), trans('lang.column') . " " . config('settings.number_1'), [
                             'class' => "col-5 form-control sub-question-option",
-                            'col-value' => 'col-value-index-' . config('settings.number_1'),
+                            'col-value' => "col-value-$questionId-index-" . config('settings.number_1'),
                         ]) !!}
                         <div class="delete-column fa fa-times"></div>
                     </div>


### PR DESCRIPTION
Summary: Display message error when user create 2 grid question that content of row/column duplicate
Step to reproduce: 
1. Open create survey
2. Create 1 grid question
3. Create 4 rows with content of rows "Hàng 1, Hàng 2, Hàng 3, Hàng 4" 
4. Create 5 column with content of column "Rất hài lòng, Hài lòng, Không hài lòng, Rất không hài lòng" 
5. Create continue a grid question
6. Create 4 rows with content of rows "Hàng 1, Hàng 2, Hàng 3, Hàng 4" 
7. Create 5 column with content of column "Rất hài lòng, Hài lòng, Không hài lòng, Rất không hài lòng" 
8. Press send
9. Observe the screen

Actual result: 
- Display message error:"Đã có một câu trả lời trùng với câu trả lời này"

Expected result:
- Enable send successfully
- Chỉ hiển thị thông báo lỗi "Đã có một câu trả lời trùng với câu trả lời này" khi có các row/column trong cùng 1 câu hỏi grid có nội dung giống nhau

![Peek 2019-06-23 20-48](https://user-images.githubusercontent.com/48110607/59977252-3465e880-95f9-11e9-87ae-2ca4f0097f1f.gif)

https://edu-redmine.sun-asterisk.vn/issues/13901