### PR TITLE
[Doing survey] User can NOT do survey after editing survey and adding redirect question.

### DIFF
--- a/app/Traits/DoSurvey.php
+++ b/app/Traits/DoSurvey.php
@@ -11,12 +11,15 @@ trait DoSurvey
 
         if ($survey->sections->where('update', config('settings.survey.section_update.updated'))->count() && Auth::user()) {
             $lastResults = $survey->results->where('user_id', Auth::user()->id)->groupBy('token')->last();
-            $redirectIds = $survey->sections->where('redirect_id', '!=', 0)->sortBy('order')->pluck('redirect_id', 'id')->all();
 
-            foreach ($redirectIds as $key => $redirectId) {
+            if ($lastResults) {
+                $redirectIds = $survey->sections->where('redirect_id', '!=', 0)->sortBy('order')->pluck('redirect_id', 'id')->all();
 
-                if (!$lastResults->where('answer_id', $redirectId)->first()) {
-                    $sectionIds = array_diff($sectionIds, [$key]);
+                foreach ($redirectIds as $key => $redirectId) {
+
+                    if (!$lastResults->where('answer_id', $redirectId)->first()) {
+                        $sectionIds = array_diff($sectionIds, [$key]);
+                    }
                 }
             }
         }


### PR DESCRIPTION
Summary: User can NOT survey after edit survey and add redirect question.

Pre- condition:* 
- Created survey
- The survey has not been done yet
Step to reproduce:* 
1. Create survey
2. Edit survey
3. Add redirect question
4. Press send
5. Click on doing survey
6. Observe the screen
Actual result: 
- Display message eror: "This page isn’t working"

Expected result: 
- User can executed survey

Note: 
- Nó chỉ xảy ra khi admin tạo survey và chỉnh sửa ngay sau đó, click vào doing survey sẽ phát sinh lỗi như trên.
![5d19af5d81710157894422](https://user-images.githubusercontent.com/48110607/60416672-9d0c2100-9c08-11e9-838e-40adcc93b56e.gif)
