### PR TITLE
Bug #14555: [Setting survey] [Copy survey] User can NOT copy survey when survey contain grid question AND Support #14736: [Copy survey] Should enable copy survey when it is any status.

### DIFF
--- a/app/Http/Controllers/Ajax/ManagementSurvey.php
+++ b/app/Http/Controllers/Ajax/ManagementSurvey.php
@@ -293,10 +293,6 @@ class ManagementSurvey extends Controller
         try {
             $survey = $this->surveyRepository->getSurveyForClone($tokenManage);
 
-            if (Auth::user()->cannot('edit', $survey)) {
-                throw new Exception("Not permitted edit!", 403);
-            }
-
             $newSurvey = $this->clone($survey);
 
             DB::commit();

--- a/app/Repositories/Question/QuestionRepository.php
+++ b/app/Repositories/Question/QuestionRepository.php
@@ -548,6 +548,11 @@ class QuestionRepository extends BaseRepository implements QuestionInterface
     {
         $data = $question->replicate()->toArray();
         $data['update'] = config('settings.survey.question_update.default');
+
+        if ($question->type == config('settings.question_type.grid')) {
+            $data['sub_questions'] = json_encode($question->sub_questions);
+        }
+
         $newQuestion = $newSection->questions()->create($data);
         // clone setting question
         $dataSettings = $question->settings->toArray();

--- a/app/Repositories/Survey/SurveyRepository.php
+++ b/app/Repositories/Survey/SurveyRepository.php
@@ -1263,9 +1263,20 @@ class SurveyRepository extends BaseRepository implements SurveyInterface
     {
         // clone survey
         $newSurvey = $survey->replicate();
+        $stringCopy = ' -' . config('settings.title_copy'); 
+        $arrTitle = explode(' ', $newSurvey->title);
+        $countCopy = substr_count($newSurvey->title, $stringCopy);
+
+        if ($countCopy) {
+            $newTitle = str_replace(end($arrTitle), end($arrTitle) + config('settings.number_1'), $newSurvey->title);
+            $newSurvey->title = $newTitle;
+        } else {
+            $newSurvey->title = $survey->title . $stringCopy . ' ' . config('settings.number_1');
+        }
+
         $newSurvey->token = md5(uniqid(rand(), true));
         $newSurvey->token_manage = md5(uniqid(rand(), true));
-        $newSurvey->status = config('settings.survey.status.close');
+        $newSurvey->status = config('settings.survey.status.open');
         $newSurvey = $this->model->create($newSurvey->toArray());
 
         // clone members

--- a/config/settings.php
+++ b/config/settings.php
@@ -358,4 +358,5 @@ return [
     'number_day_backup' => 7,
     'linear_scale_icon' => '/templates/survey/images/linear_scale.png',
     'limit_grid' => 15, 
+    'title_copy' => 'Copy',
 ];


### PR DESCRIPTION
Fix lỗi có thể copy Survey cho dù ở bất kỳ trạng thái nào ( đóng hoặc mở ).
Fix lỗi không thể copy được câu hỏi dạng gird.
Fix lỗi khi copy servey xong thì servey sẽ ở trạng thái "Mở".
Fix thêm chữ - Copy khi copy một servey.
![Peek 2019-07-09 08-46](https://user-images.githubusercontent.com/48110607/60853438-41542000-a226-11e9-9823-0aa27f55a5ef.gif)
