### PR TITLE
Bug #14849: [Doing survey][Limit replies] User can NOT edit answer when setting limit replies.

### DIFF
--- a/app/Http/Kernel.php
+++ b/app/Http/Kernel.php
@@ -57,5 +57,6 @@ class Kernel extends HttpKernel
         'supperadmin' => \App\Http\Middleware\RedirectIfNotSupperAdmin::class,
         'profile' => \App\Http\Middleware\ProfileMiddleware::class,
         'doingsurvey' => \App\Http\Middleware\DoingSurveyMiddleware::class,
+        'editanswer' => \App\Http\Middleware\EditAnswerMiddleware::class,
     ];
 }

--- a/app/Http/Middleware/EditAnswerMiddleware.php
+++ b/app/Http/Middleware/EditAnswerMiddleware.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use Closure;
+use App\Repositories\Survey\SurveyInterface;
+use App\Repositories\User\UserInterface;
+use Auth;
+use Illuminate\Http\Response;
+use App\Policies\SurveyPolicy;
+use App\Traits\SurveyProcesser;
+
+class EditAnswerMiddleware
+{
+    use SurveyProcesser;
+
+    /**
+     * Handle an incoming request.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @param  \Closure  $next
+     * @return mixed
+     */
+    protected $surveyRepository;
+    protected $userRepository;
+
+    public function __construct(SurveyInterface $surveyRepository, UserInterface $userRepository)
+    {
+        $this->surveyRepository = $surveyRepository;
+        $this->userRepository = $userRepository;
+    }
+
+    public function handle($request, Closure $next)
+    {
+        $survey = $this->surveyRepository->getSurveyFromToken($request->token);
+        $status = $survey->status;
+        $limitAnswer = $survey->getLimitAnswer();
+        $title = $survey->title;
+
+        if ($status != config('settings.survey.status.open')
+            && (!Auth::check() || Auth::user()->cannot('edit', $survey))) {
+            $content = trans('lang.you_do_not_have_permission');
+
+            return new Response(view('clients.survey.detail.complete', compact('title', 'content')));
+        }
+
+        if (!Auth::check()) {
+            $requiredLogin = $survey->required;
+            $privacy = $survey->getPrivacy();
+
+            if ($privacy == config('settings.survey_setting.privacy.private')) {
+                $requiredLogin = config('settings.survey_setting.answer_required.login');
+            }
+
+            if ($requiredLogin) {
+                return new Response(view('clients.survey.detail.index', compact('requiredLogin')));
+            }
+        }
+
+        return $next($request);
+    }
+}

--- a/routes/web.php
+++ b/routes/web.php
@@ -404,7 +404,7 @@ Route::post('store-result', [
 Route::get('edit-answer/{token}/{tokenResult}', [
     'uses' => 'SurveyController@editAnswer',
     'as' => 'survey.create.edit-answer',
-])->middleware('doingsurvey');
+])->middleware('editanswer');
 
 Route::post('store-edit-answer', [
     'uses' => 'SurveyController@storeNewResults',


### PR DESCRIPTION
*Pre-condition: 
- Create survey with limit replies = 2
- Enable editing answer

Step to reproduce: 
1. Create survey
2. Setting limit survey = 2
3. Doing survey
4. Edit answer
5. Press send survey
6. Doing survey
7. Edit survey
8. observe the screen

Actual result:
- Nếu làm khảo sát lần đầu có thể edit answer. 
- Kể từ lần thứ 2 làm survey và gửi hệ thống sẽ không cho edit answer.

Expected result: 
- Cho phép edit survey dù hạn chế số lần làm khảo sát.

![Peek 2019-07-11 14-49](https://user-images.githubusercontent.com/48110607/61032302-5f1eb200-a3eb-11e9-8faa-d8224e54d2d7.gif)
