### PR TITLE
[List survey] The system display the columns incorrectly in table list when user click on pagination.

### DIFF
--- a/app/Http/Controllers/Ajax/SurveyController.php
+++ b/app/Http/Controllers/Ajax/SurveyController.php
@@ -97,7 +97,7 @@ class SurveyController extends Controller
         $data = $request->only('name', 'status', 'privacy');
         $surveys = $this->surveyRepository->getAllSurvey($data);
 
-        $html = view('clients.profile.survey.list_survey_owner', compact('surveys'))->render();
+        $html = view('clients.profile.survey.list_survey_manage', compact('surveys'))->render();
 
         return response()->json([
             'success' => true,

--- a/config/settings.php
+++ b/config/settings.php
@@ -340,7 +340,9 @@ return [
     'date_format_vn' => 'DD/MM/YYYY',
     'date_format_en' => 'MM/DD/YYYY',
     'date_format_jp' => 'YYYY/MM/DD',
+    'date_time_format' => 'd-m-Y H:i:s',
     'group_content_result' => '',
+    'current_page' => 1,
 
     /**
      *  Survey edit

--- a/resources/assets/templates/survey/css/form-builder-custom.css
+++ b/resources/assets/templates/survey/css/form-builder-custom.css
@@ -4114,6 +4114,14 @@ input[name="quantity-answer"]::-webkit-outer-spin-button, input[type="number"]::
     border-bottom: 1px dotted #333;
 }
 
+.width-25 {
+    width: 25%;
+}
+
+.width-16 {
+    width: 16%;
+}
+
 /* dropdown */
 
 .sel {

--- a/resources/views/clients/profile/list-survey.blade.php
+++ b/resources/views/clients/profile/list-survey.blade.php
@@ -29,7 +29,7 @@
             @include('clients.profile.survey.element.search')
 
             <div class="table-responsive" id="show-list-surveys">
-                @include('clients.profile.survey.list_survey_owner')
+                @include('clients.profile.survey.list_survey_manage')
             </div>
         </div>
     </div>

--- a/resources/views/clients/profile/survey/list_survey_manage.blade.php
+++ b/resources/views/clients/profile/survey/list_survey_manage.blade.php
@@ -3,17 +3,23 @@
         <thead>
             <tr>
                 <th class="text-center">@lang('profile.index')</th>
-                <th width="25%" class="text-center">@lang('profile.name_survey')</th>
+                <th class="text-center width-25">@lang('profile.name_survey')</th>
                 <th class="text-center">@lang('profile.status')</th>
+                @if(Request::path() == config('settings.path_list_survey'))
                 <th class="text-center">@lang('survey.inviting')</th>
                 <th class="text-center">@lang('survey.remaining_time')</th>
-                <th width="16%"></th>
+                @else
+                <th class="text-center">@lang('lang.owner')</th>
+                <th class="text-center">@lang('lang.start_time')</th>
+                <th class="text-center">@lang('lang.end_time')</th>
+                @endif
+                <th class="width-16"></th>
             </tr>
         </thead>
         <tbody>
             @foreach ($surveys as $survey)
                 <tr>
-                    <td class="text-center">{{ $surveys->currentPage() == 1 ? $loop->iteration : $loop->iteration + $surveys->perPage() * ($surveys->currentPage() - 1) }}</td>
+                    <td class="text-center">{{ $surveys->currentPage() == config('settings.current_page') ? $loop->iteration : $loop->iteration + $surveys->perPage() * ($surveys->currentPage() - config('settings.current_page')) }}</td>
                     <td>
                         @if ($survey->status == config('settings.survey.status.open'))
                             <a href="{{ route('survey.create.do-survey', $survey->token) }}" target="_blank" data-toggle="tooltip" title="{{ $survey->title }}">{{ $survey->trim_title }}</a>
@@ -25,6 +31,7 @@
                         <span class="badge badge-info badge-list-survey">{{ $survey->settings->first()->value == config('settings.survey_setting.privacy.public') ? trans('profile.public') :  trans('profile.private') }}</span>
                         <span class="badge badge-secondary badge-list-survey">{{ $survey->status_custom }}</span>
                     </td>
+                    @if(Request::path() == config('settings.path_list_survey'))
                     <td>
                         @php
                             $invites = $survey->getInvites();
@@ -42,6 +49,11 @@
                     <td>
                         <span class="badge badge-info badge-list-survey">{{ $survey->remaining_time ? $survey->remaining_time : '' }}</span>
                     </td>
+                    @else
+                    <td class="owner-name">{{$survey->owner_name}}</td>
+                    <td>{{date(config('settings.date_time_format'), strtotime($survey->start_time))}}</td>
+                    <td>{{ $survey->end_time ? date(config('settings.date_time_format'), strtotime($survey->end_time)) : '-- -- --'}}</td>
+                    @endif
                     <td>
                         <a href="{{ route('survey.management', $survey->token_manage) }}" class="btn btn-info" data-toggle="tooltip" title="@lang('lang.setting')">
                             <i class="fa fa-cog" aria-hidden="true"></i>
@@ -49,7 +61,8 @@
                         @can('delete', $survey)
                             <a href="javascript:void(0)" class="btn btn-danger" id="delete-survey"
                                 data-toggle="tooltip" title="@lang('survey.delete')"
-                                data-url="{{ route('ajax-survey-delete', $survey->token_manage) }}">
+                                data-url="{{ route('ajax-survey-delete', $survey->token_manage) }}"
+                                data-survey-status="{{ $survey->status }}">
                                 <i class="fa fa-trash" aria-hidden="true"></i>
                             </a>
                         @endcan


### PR DESCRIPTION
Summary: The system display the columns incorrectly when user click on pagination.

Pre-condition:
- There are more than 15 surveys

Step to re-produce: 
1. Open list survey
2. Click on paginaton
3. Observe the screen

Actual resul: 
- Display table with columns "Index/ Name survey/ Status/ Owner/ Start time/ End time"

Actual result: 
- Display table with columns "Index/ Name survey/ Status/ Inviting/ Remaining Time"

https://edu-redmine.sun-asterisk.vn/issues/16822