### PR TITLE
[Setting survey] [Delete survey] The system still display message 'The survey is opening, you must close the survey before deleting!' Although user closed survey .

### DIFF
--- a/resources/assets/templates/survey/js/builder-custom.js
+++ b/resources/assets/templates/survey/js/builder-custom.js
@@ -4084,7 +4084,11 @@ jQuery(document).ready(function () {
         } else {
             sectionDuplicate = element.closest('.page-section').clone();
             sectionDuplicate.insertAfter(element.closest('.page-section'));
-            refreshIdSectionDuplicate(sectionDuplicate);
+            $(this).closest('ul.page-section').find('.form-line.sort').each(function () {
+                if ($(this).data('question-type') == 11) {
+                    return false;
+                } else refreshIdSectionDuplicate(sectionDuplicate);
+            })
         }
 
         formSortable();

--- a/resources/assets/templates/survey/js/management.js
+++ b/resources/assets/templates/survey/js/management.js
@@ -213,7 +213,11 @@ $(document).ready(function () {
 
     // delete survey
     $(document).on('click', '#delete-survey', function () {
-        if ($(this).data('survey-status') == 1) {
+        var deleteSurveyCondition = window.location.pathname == '/list-survey'
+            ? $(this).data('survey-status') == 1
+            : $('.btn.hide-div').attr('id') == 'open-survey';
+
+        if (deleteSurveyCondition) {
             alertWarning(
                 { message: Lang.get('lang.warning_close_survey_to_delete') }
             );


### PR DESCRIPTION
Summary: The system still display message "The survey is opening, you must close the survey before deleting!" Although user closed survey .

Pre-condition: 
- Created survey

Step to reproduce: 
1. Open setting survey page 
2. Click on icon close survey
3. Click on icon delete survey 
4. Observe display message.

Actual result: 
- Display message error : "The survey is opening, you must close the survey before deleting!"

Expected result: 
- Enable delete survey when user closed survey